### PR TITLE
Inertia v0.2.0

### DIFF
--- a/inertia.rb
+++ b/inertia.rb
@@ -3,7 +3,7 @@ class Inertia < Formula
   homepage "https://github.com/ubclaunchpad/inertia"
   version "0.2.0"
   url "https://github.com/ubclaunchpad/inertia/releases/download/v#{version}/inertia.v#{version}.darwin.386"
-  sha256 "a687116c7fe155ed2150f86843f933c506eeb5335547e79e4786dec2ae16fc6b"
+  sha256 "b656483ba3058a38c04a9c398f911ce99dba2937e0352221c88597622b3013f8"
   bottle :unneeded
 
   def install

--- a/inertia.rb
+++ b/inertia.rb
@@ -1,7 +1,7 @@
 class Inertia < Formula
   desc "Simple, self-hosted continuous deployment"
   homepage "https://github.com/ubclaunchpad/inertia"
-  version "0.1.1"
+  version "0.2.0"
   url "https://github.com/ubclaunchpad/inertia/releases/download/v#{version}/inertia.v#{version}.darwin.386"
   sha256 "a687116c7fe155ed2150f86843f933c506eeb5335547e79e4786dec2ae16fc6b"
   bottle :unneeded


### PR DESCRIPTION
Release: https://github.com/ubclaunchpad/inertia/releases/tag/v0.2.0

```bash
bobbook:homebrew-tap robertlin$ brew install inertia.rb
==> Downloading https://github.com/ubclaunchpad/inertia/releases/download/v0.2.0/inertia.v0.2.0.darwin.386
Already downloaded: /Users/robertlin/Library/Caches/Homebrew/inertia-0.2.0.386
🍺  /usr/local/Cellar/inertia/0.2.0: 3 files, 13MB, built in 1 second
bobbook:homebrew-tap robertlin$ inertia --version
inertia version v0.2.0
```