### PR TITLE
Inertia v0.3.0

### DIFF
--- a/inertia.rb
+++ b/inertia.rb
@@ -1,9 +1,9 @@
 class Inertia < Formula
   desc "Simple, self-hosted continuous deployment"
   homepage "https://github.com/ubclaunchpad/inertia"
-  version "0.2.0"
+  version "0.3.0"
   url "https://github.com/ubclaunchpad/inertia/releases/download/v#{version}/inertia.v#{version}.darwin.386"
-  sha256 "b656483ba3058a38c04a9c398f911ce99dba2937e0352221c88597622b3013f8"
+  sha256 "6acff87b76e1ec38c2c9f89f77d196e15fcc5bab1b0230e9b2905b27bbb0b20f"
   bottle :unneeded
 
   def install


### PR DESCRIPTION
https://github.com/ubclaunchpad/inertia/releases/tag/v0.3.0

```bash
bobbook:homebrew-tap robertlin$ brew install inertia.rb
==> Downloading https://github.com/ubclaunchpad/inertia/releases/download/v0.3.0/inertia.v0.3.0.da
Already downloaded: /Users/robertlin/Library/Caches/Homebrew/inertia-0.3.0.386
🍺  /usr/local/Cellar/inertia/0.3.0: 3 files, 13.4MB, built in 1 second
bobbook:homebrew-tap robertlin$ inertia --version
inertia version v0.3.0
```