### PR TITLE
Add HEAD formula to build Inertia from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ brew tap ubclaunchpad/tap
 ## Available Formulae
 
 - [**`inertia`**](https://github.com/ubclaunchpad/inertia) — Effortless, self-hosted continuous deployment for small teams and projects
-    - install with the `--devel` flag for prereleases
+    - install with `--devel` for prereleases
+    - install with `--HEAD` to build from trunk
 
 - [**`cumulus`**](https://github.com/ubclaunchpad/cumulus) — Cryptocurrency that doesn't waste your time
 

--- a/inertia.rb
+++ b/inertia.rb
@@ -1,20 +1,41 @@
 class Inertia < Formula
   desc "Simple, self-hosted continuous deployment"
   homepage "https://github.com/ubclaunchpad/inertia"
+  bottle :unneeded
+
+  # Stable
   version "0.4.0"
   url "https://github.com/ubclaunchpad/inertia/releases/download/v#{version}/inertia.v#{version}.darwin.386"
   sha256 "b924b123eb852969489572b46404e416728e78519ca3c6025f0441124a2e7024"
-  bottle :unneeded
 
-  def install
-    mv "inertia.v#{version}.darwin.386", "inertia"
-    bin.install "inertia"
-  end
-
+  # Prerelease
   devel do
     version "0.4.0"
     url "https://github.com/ubclaunchpad/inertia/releases/download/v#{version}/inertia.v#{version}.darwin.386"
     sha256 "b924b123eb852969489572b46404e416728e78519ca3c6025f0441124a2e7024"
+  end
+
+  # Build from latest commit
+  head "https://github.com/ubclaunchpad/inertia.git"
+  head do
+    version "latest"
+    depends_on "dep"
+    depends_on "go" => :build
+  end
+
+  def install
+    if build.head?
+      ENV["GOPATH"] = buildpath
+      path = buildpath/"src/github.com/ubclaunchpad/inertia"
+      system "go", "get", "-u", "github.com/ubclaunchpad/inertia"
+      cd path do
+        system "dep", "ensure"
+        system "go", "build", "-o", "#{bin}/inertia"
+      end
+    else
+      mv "inertia.v#{version}.darwin.386", "inertia"
+      bin.install "inertia"
+    end
   end
 
   test do


### PR DESCRIPTION
`--HEAD` flag  🎧 

```bash
$> inertia --version
bash: /usr/local/bin/inertia: No such file or directory
$> brew install ./inertia.rb --HEAD
==> Cloning https://github.com/ubclaunchpad/inertia.git
Updating /Users/robertlin/Library/Caches/Homebrew/inertia--git
==> Checking out branch master
==> go get -u github.com/ubclaunchpad/inertia
==> dep ensure
==> go build -o /usr/local/Cellar/inertia/HEAD-ab144d7/bin/inertia
🍺  /usr/local/Cellar/inertia/HEAD-ab144d7: 5 files, 21.1MB, built in 1 minute 11 seconds
$> inertia --version
[WARNING] Inertia configuration not found in inertia.toml
inertia version latest
```