### PR TITLE
Inertia v0.5.0-rc1

### DIFF
--- a/inertia.rb
+++ b/inertia.rb
@@ -10,9 +10,9 @@ class Inertia < Formula
 
   # Prerelease
   devel do
-    version "0.4.4"
-    url "https://github.com/ubclaunchpad/inertia/releases/download/v#{version}/inertia.v#{version}.darwin.386"
-    sha256 "12d967a0378924e48062457acc812c2741b634b9ec3a2724c7340ea285986c16"
+    version "0.5.0-rc1"
+    url "https://github.com/ubclaunchpad/inertia/releases/download/v#{version}/inertia.v#{version}.darwin.amd64"
+    sha256 "1288a4d39add6a93977eb60f888abf0d1a718a08e156b1d87f10412153fa08ef"
   end
 
   # Build from latest commit
@@ -33,7 +33,11 @@ class Inertia < Formula
         system "go", "build", "-o", "#{bin}/inertia"
       end
     else
-      mv "inertia.v#{version}.darwin.386", "inertia"
+      if build.devel?
+        mv "inertia.v#{version}.darwin.amd64", "inertia"
+      else
+        mv "inertia.v#{version}.darwin.386", "inertia"
+      end
       bin.install "inertia"
     end
   end


### PR DESCRIPTION
```sh
~/Projects/ubclaunchpad/homebrew-tap master*
❯ brew install inertia.rb --devel
==> Downloading https://github.com/ubclaunchpad/inertia/releases/download/v0.5.0-rc1/inertia.v0.5.0-rc1.darwin.amd64
Already downloaded: /Users/robertlin/Library/Caches/Homebrew/downloads/0f6044d979686324f996c2c4ae769875460ff4d8172c44868aceb6d694d1b2ec--inertia.v0.5.0-rc1.darwin.amd64
🍺  /usr/local/Cellar/inertia/0.5.0-rc1: 3 files, 18.9MB, built in 3 seconds

~/Projects/ubclaunchpad/homebrew-tap master* 6s
❯ inertia --version
[WARNING] Inertia configuration not found in inertia.toml
inertia version v0.5.0-rc1
```